### PR TITLE
Added alpha mechs compatability + Mechanoids upgrades compabability + Reduced the price increases to vanilla research

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -24,5 +24,6 @@
 		<li>vanillaracesexpanded.android</li>
 		<li>rhiom.conveyorbelts.1.02</li>
 		<li>sarg.alphamechs</li>
+		<li>gogatio.mechanoidupgrades</li>
 	</loadAfter>
 </ModMetaData>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -5,6 +5,7 @@
     <li IfModActive="vanillaracesexpanded.android">Mods and Shit/VRE Androids</li>
     <li IfModActive="rhiom.conveyorbelts.1.02">Mods and Shit/Conveyor Belts</li>
     <li IfModActive="sarg.alphamechs">Mods and Shit/Alpha Mechs</li>
+    <li IfModActive="gogatio.mechanoidupgrades">Mods and Shit/Mechanoid Upgrades</li>
   </v1.4>
   <v1.5>
     <li>/</li>
@@ -12,5 +13,6 @@
     <li IfModActive="vanillaracesexpanded.android">Mods and Shit/VRE Androids</li>
     <li IfModActive="rhiom.conveyorbelts.1.02">Mods and Shit/Conveyor Belts</li>
     <li IfModActive="sarg.alphamechs">Mods and Shit/Alpha Mechs</li>
+    <li IfModActive="gogatio.mechanoidupgrades">Mods and Shit/Mechanoid Upgrades</li>
   </v1.5>
 </loadFolders>

--- a/Mods and Shit/Alpha Mechs/Patches/Smxrez_AlphaMechsPatches.xml
+++ b/Mods and Shit/Alpha Mechs/Patches/Smxrez_AlphaMechsPatches.xml
@@ -30,6 +30,78 @@
             </li>
           </value>
         </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="AM_WorkerStandardMechtech"]/baseCost</xpath>
+          <value>
+           <baseCost>500</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="AM_StandardMechtech"]/baseCost</xpath>
+          <value>
+           <baseCost>1000</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="AM_HeavyMechtech"]/baseCost</xpath>
+          <value>
+           <baseCost>1500</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="AM_UltraHeavyMechtech"]/baseCost</xpath>
+          <value>
+           <baseCost>3000</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="AM_AlphaHardwareUpgrade"]/baseCost</xpath>
+          <value>
+           <baseCost>2000</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="AM_MechanoidBeamcasting"]/baseCost</xpath>
+          <value>
+           <baseCost>3000</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="AM_VoidLinkConnectivity"]/baseCost</xpath>
+          <value>
+           <baseCost>4000</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="AM_QuantumPulseMessaging"]/baseCost</xpath>
+          <value>
+           <baseCost>5000</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="AM_Cryptoharmonization"]/baseCost</xpath>
+          <value>
+           <baseCost>6000</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ResearchProjectDef[defName="AM_WorkerStandardMechtech"]</xpath>
+          <value>
+           <techLevel>Spacer</techLevel>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ResearchProjectDef[defName="AM_StandardMechtech"]</xpath>
+          <value>
+           <techLevel>Spacer</techLevel>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ResearchProjectDef[defName="AM_HeavyMechtech"]</xpath>
+          <value>
+           <techLevel>Spacer</techLevel>
+          </value>
+        </li>
       </operations>
     </match>
   </Operation>

--- a/Mods and Shit/Alpha Mechs/Patches/Smxrez_AlphaMechsPatches.xml
+++ b/Mods and Shit/Alpha Mechs/Patches/Smxrez_AlphaMechsPatches.xml
@@ -2,7 +2,7 @@
 <Patch>
   <Operation Class="PatchOperationFindMod">
     <mods>
-      <li>Alpha Mechs</li>
+      <li>Biotech</li>
     </mods>
     <match Class="PatchOperationSequence">
       <operations>
@@ -30,34 +30,160 @@
             </li>
           </value>
         </li>
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/ResearchProjectDef[defName="AM_WorkerStandardMechtech"]/baseCost</xpath>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_DaggersnoutRecipe"]</xpath>
           <value>
-           <baseCost>500</baseCost>
+            <researchPrerequisite>BasicMechtech</researchPrerequisite>
           </value>
         </li>
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/ResearchProjectDef[defName="AM_StandardMechtech"]/baseCost</xpath>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_BellicorRecipe"]</xpath>
           <value>
-           <baseCost>1000</baseCost>
+            <researchPrerequisite>StandardMechtech</researchPrerequisite>
           </value>
         </li>
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/ResearchProjectDef[defName="AM_HeavyMechtech"]/baseCost</xpath>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_ArtilleronRecipe"]</xpath>
           <value>
-           <baseCost>1500</baseCost>
+            <researchPrerequisite>StandardMechtech</researchPrerequisite>
           </value>
         </li>
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/ResearchProjectDef[defName="AM_UltraHeavyMechtech"]/baseCost</xpath>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_BlitzkriegRecipe"]</xpath>
           <value>
-           <baseCost>3000</baseCost>
+            <researchPrerequisite>BasicMechtech</researchPrerequisite>
           </value>
         </li>
-        <li Class="PatchOperationReplace">
-          <xpath>Defs/ResearchProjectDef[defName="AM_AlphaHardwareUpgrade"]/baseCost</xpath>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_Mech_MasterChefRecipe"]</xpath>
           <value>
-           <baseCost>2000</baseCost>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_Mech_TurboCleanerRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>StandardMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_AuraRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>StandardMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_LuxRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_PolychoronRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_OptioRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_MunifexRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_Mech_SagittariusRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_PristineStriderRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>StandardMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_PristineAssemblerRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>StandardMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_PristineSlurrypedeRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>StandardMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_DemolisherRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_GoliathRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_FirewormRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_PhalanxRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_SiegebreakerRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>AM_QuantumPulseMessaging</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_SiegemelterRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>AM_QuantumPulseMessaging</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_StarfireRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>AM_Cryptoharmonization</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_Mech_LegateRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>AM_VoidLinkConnectivity</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_InfernusRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>AM_VoidLinkConnectivity</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_WarEmpressRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>AM_QuantumPulseMessaging</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/RecipeDef[defName="AM_ApoptosisRecipe"]</xpath>
+          <value>
+            <researchPrerequisite>AM_Cryptoharmonization</researchPrerequisite>
           </value>
         </li>
         <li Class="PatchOperationReplace">
@@ -84,23 +210,62 @@
            <baseCost>6000</baseCost>
           </value>
         </li>
-        <li Class="PatchOperationAdd">
+        <li Class="PatchOperationRemove">
           <xpath>Defs/ResearchProjectDef[defName="AM_WorkerStandardMechtech"]</xpath>
-          <value>
-           <techLevel>Spacer</techLevel>
-          </value>
         </li>
-        <li Class="PatchOperationAdd">
+        <li Class="PatchOperationRemove">
           <xpath>Defs/ResearchProjectDef[defName="AM_StandardMechtech"]</xpath>
+        </li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/ResearchProjectDef[defName="AM_HeavyMechtech"]</xpath>
+        </li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/ResearchProjectDef[defName="AM_UltraHeavyMechtech"]</xpath>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/RecipeDef[defName="AM_DominionRecipe"]/researchPrerequisite</xpath>
           <value>
-           <techLevel>Spacer</techLevel>
+            <researchPrerequisite>VFE_HardwareUpgrade</researchPrerequisite>
           </value>
         </li>
-        <li Class="PatchOperationAdd">
-          <xpath>Defs/ResearchProjectDef[defName="AM_HeavyMechtech"]</xpath>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/RecipeDef[defName="AM_EvisceratorRecipe"]/researchPrerequisite</xpath>
           <value>
-           <techLevel>Spacer</techLevel>
+            <researchPrerequisite>VFE_HardwareUpgrade</researchPrerequisite>
           </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/RecipeDef[defName="AM_IncineratorRecipe"]/researchPrerequisite</xpath>
+          <value>
+            <researchPrerequisite>VFE_HardwareUpgrade</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/RecipeDef[defName="AM_ColossusRecipe"]/researchPrerequisite</xpath>
+          <value>
+            <researchPrerequisite>VFE_HardwareUpgrade</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/RecipeDef[defName="AM_HopliteRecipe"]/researchPrerequisite</xpath>
+          <value>
+            <researchPrerequisite>VFE_HardwareUpgrade</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/RecipeDef[defName="AM_SiegemasterRecipe"]/researchPrerequisite</xpath>
+          <value>
+            <researchPrerequisite>VFE_HardwareUpgrade</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/RecipeDef[defName="AM_PristineSlurrymasterRecipe"]/researchPrerequisite</xpath>
+          <value>
+            <researchPrerequisite>VFE_HardwareUpgrade</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationRemove">
+          <xpath>Defs/ResearchProjectDef[defName="AM_AlphaHardwareUpgrade"]</xpath>
         </li>
       </operations>
     </match>

--- a/Mods and Shit/Mechanoid Upgrades/Patches/Smxrez_MechUpgradePatches.xml
+++ b/Mods and Shit/Mechanoid Upgrades/Patches/Smxrez_MechUpgradePatches.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Mechanoid Upgrades</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_BasicUpgrades"]/baseCost</xpath>
+          <value>
+           <baseCost>1000</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ResearchProjectDef[defName="MU_BasicUpgrades"]</xpath>
+          <value>
+           <techLevel>Spacer</techLevel>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_BasicChips"]/baseCost</xpath>
+          <value>
+           <baseCost>350</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ResearchProjectDef[defName="MU_BasicChips"]</xpath>
+          <value>
+           <techLevel>Spacer</techLevel>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_BasicModules"]/baseCost</xpath>
+          <value>
+           <baseCost>400</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ResearchProjectDef[defName="MU_BasicModules"]</xpath>
+          <value>
+           <techLevel>Spacer</techLevel>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_BasicArmor"]/baseCost</xpath>
+          <value>
+           <baseCost>300</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ResearchProjectDef[defName="MU_BasicArmor"]</xpath>
+          <value>
+           <techLevel>Spacer</techLevel>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_BasicShields"]/baseCost</xpath>
+          <value>
+           <baseCost>700</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ResearchProjectDef[defName="MU_BasicShields"]</xpath>
+          <value>
+           <techLevel>Spacer</techLevel>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_Burners"]/baseCost</xpath>
+          <value>
+           <baseCost>800</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ResearchProjectDef[defName="MU_Burners"]</xpath>
+          <value>
+           <techLevel>Spacer</techLevel>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_Grenades"]/baseCost</xpath>
+          <value>
+           <baseCost>400</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ResearchProjectDef[defName="MU_Grenades"]</xpath>
+          <value>
+           <techLevel>Spacer</techLevel>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_StandardUpgrades"]/baseCost</xpath>
+          <value>
+           <baseCost>1600</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_StandardChips"]/baseCost</xpath>
+          <value>
+           <baseCost>750</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_StandardModules"]/baseCost</xpath>
+          <value>
+           <baseCost>800</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_StandardArmor"]/baseCost</xpath>
+          <value>
+           <baseCost>700</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_StandardShields"]/baseCost</xpath>
+          <value>
+           <baseCost>1100</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_JumpLauncher"]/baseCost</xpath>
+          <value>
+           <baseCost>850</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_CommandExtenders"]/baseCost</xpath>
+          <value>
+           <baseCost>2500</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_AdvancedUpgrades"]/baseCost</xpath>
+          <value>
+           <baseCost>2000</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_AdvancedChips"]/baseCost</xpath>
+          <value>
+           <baseCost>1050</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_AdvancedModules"]/baseCost</xpath>
+          <value>
+           <baseCost>1100</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_AdvancedArmor"]/baseCost</xpath>
+          <value>
+           <baseCost>1000</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_AdvancedShields"]/baseCost</xpath>
+          <value>
+           <baseCost>1450</baseCost>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ResearchProjectDef[defName="MU_ShieldBooster"]/baseCost</xpath>
+          <value>
+           <baseCost>1200</baseCost>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/Patches/VanillaPatches.xml
+++ b/Patches/VanillaPatches.xml
@@ -40,19 +40,13 @@
     <li Class="PatchOperationReplace">
         <xpath>Defs/ResearchProjectDef[defName="StandardMechtech"]/baseCost</xpath>
         <value>
-            <baseCost>3000</baseCost>
+            <baseCost>2500</baseCost>
         </value>
     </li>
         <li Class="PatchOperationReplace">
         <xpath>Defs/ResearchProjectDef[defName="HighMechtech"]/baseCost</xpath>
         <value>
-            <baseCost>4500</baseCost>
-        </value>
-    </li>
-        <li Class="PatchOperationReplace">
-        <xpath>Defs/ResearchProjectDef[defName="UltraMechtech"]/baseCost</xpath>
-        <value>
-            <baseCost>6000</baseCost>
+            <baseCost>3500</baseCost>
         </value>
     </li>
     <li Class="PatchOperationReplace">


### PR DESCRIPTION
- Made all industrial alpha mechs research spacer tech and heavily increased research costs across the board to be more balanced as the default prices were insanely cheap.
- Made all industrial mechanoid upgrades research spacer tech and slightly increased research costs across the board
- Reduced vanilla research prices as they felt too much with all the other mech research modded adds
- Loadfolders.xml and About.xml both got updated to have stuff for mechanoid upgrades