### PR TITLE
Update patch for Alpha Mechs to cover mod-specific mechs

### DIFF
--- a/Mods and Shit/Alpha Mechs/Patches/Smxrez_AlphaMechsPatches.xml
+++ b/Mods and Shit/Alpha Mechs/Patches/Smxrez_AlphaMechsPatches.xml
@@ -186,6 +186,42 @@
             <researchPrerequisite>AM_Cryptoharmonization</researchPrerequisite>
           </value>
         </li>
+        <li Class="PatchOperationAdd" MayRequire="vanillaracesexpanded.sanguophage">
+          <xpath>Defs/RecipeDef[defName="AM_Gestate_Sanguinarius"]/researchPrerequisite</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace" MayRequire="vanillaexpanded.vgeneticse">
+          <xpath>Defs/RecipeDef[defName="AM_Gestate_Geneticor"]/researchPrerequisite</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace" MayRequire="vanillaexpanded.vcef">
+          <xpath>Defs/RecipeDef[defName="AM_Gestate_Angler"]/researchPrerequisite</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace" MayRequire="vanillaexpanded.vbookse">
+          <xpath>Defs/RecipeDef[defName="AM_Gestate_Librarian"]/researchPrerequisite</xpath>
+          <value>
+            <researchPrerequisite>HighMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace" MayRequire="sarg.rimbees">
+          <xpath>Defs/RecipeDef[defName="AM_Gestate_Apiarist"]/researchPrerequisite</xpath>
+          <value>
+            <researchPrerequisite>BasicMechtech</researchPrerequisite>
+          </value>
+        </li>
+        <li Class="PatchOperationReplace" MayRequire="Dubwise.Rimatomics">
+          <xpath>Defs/RecipeDef[defName="AM_Gestate_Nucleotron"]/researchPrerequisite</xpath>
+          <value>
+            <researchPrerequisite>BasicMechtech</researchPrerequisite>
+          </value>
+        </li>
         <li Class="PatchOperationReplace">
           <xpath>Defs/ResearchProjectDef[defName="AM_MechanoidBeamcasting"]/baseCost</xpath>
           <value>


### PR DESCRIPTION
Add patches to replace the research prerequisites for the gestation recipes of the following mechs:

- Sanguinarius (VFE - Sanguophage)
- Geneticor (Vanilla Genetics Expanded)
- Angler (Vanilla Fishing Expanded)
- Librarian (Vanilla Books Expanded)
- Apiarist (Alpha Bees)
- Nucleotron (Rimatomics)